### PR TITLE
Explicitly install torchvision

### DIFF
--- a/PyTorchUtils/Resources/UI/PyTorchUtils.ui
+++ b/PyTorchUtils/Resources/UI/PyTorchUtils.ui
@@ -43,7 +43,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>NVidia driver:</string>
+         <string>NVIDIA driver:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Make sure torchvision is installed along with torch. Some pytorch-based tools needs torchvision and it is a very small additional package.

Also made a few small style improvements:
- use PyTorchUtilsLogic. instead of self.logic. to access static methods
- correct capitalization of NVIDIA (not NVidia)
- if NVIDIA driver is not found then display "not found" instead of "unknown"