### PR TITLE
Allow specifying pytorch version for installation

### DIFF
--- a/PyTorchUtils/Resources/UI/PyTorchUtils.ui
+++ b/PyTorchUtils/Resources/UI/PyTorchUtils.ui
@@ -63,14 +63,14 @@
       <string>Install/uninstall</string>
      </property>
      <layout class="QFormLayout" name="formLayout_4">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Computation backend:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QComboBox" name="backendComboBox">
@@ -110,27 +110,44 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QPushButton" name="installPushButton">
         <property name="text">
          <string>Install PyTorch</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QPushButton" name="uninstallPushButton">
         <property name="text">
          <string>Uninstall PyTorch</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QPushButton" name="restartPushButton">
         <property name="toolTip">
          <string>Restart Slicer. If PyTorch is in use, the application must be restarted before it can be uninstalled.</string>
         </property>
         <property name="text">
          <string>Restart the application</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>PyTorch version requirement:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="torchVersionLineEdit">
+        <property name="toolTip">
+         <string>Optional version requirement for installing PyTorch. For example, to install PyTorch version 1.12 or later, set this to &quot;&gt;=1.12&quot;. The field has no effect if PyTorch is already installed.</string>
+        </property>
+        <property name="placeholderText">
+         <string>default</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The main motivation for this is that on some computers when installing PyTorch with default options, a very old version (1.8.1) is installed. The new API and GUI allows specifying a requirement (e.g., ">=1.12" or ">=2").

While this does not address the question of why old version is installed by default, it allows modules to automatically install correct pytorch version and allows users to manually specify a version, if effectively fixes #9