### PR TITLE
BUG: Install light-the-torch from Slicer fork for cu128+ GPU support

### DIFF
--- a/PyTorchUtils/PyTorchUtils.py
+++ b/PyTorchUtils/PyTorchUtils.py
@@ -244,9 +244,7 @@ class PyTorchUtilsLogic(ScriptedLoadableModuleLogic):
 
   @staticmethod
   def _installLightTheTorch():
-    # Install from the Slicer fork which includes support for newer CUDA
-    # versions (cu128+) needed for Blackwell and newer GPU architectures.
-    # The upstream PyPI release (0.8.0) only supports up to cu126.
+    # Install from the Slicer fork which is maintained for newer CUDA versions
     slicer.util.pip_install(
       'https://github.com/Slicer/light-the-torch/archive/main.zip')
 

--- a/PyTorchUtils/PyTorchUtils.py
+++ b/PyTorchUtils/PyTorchUtils.py
@@ -244,7 +244,11 @@ class PyTorchUtilsLogic(ScriptedLoadableModuleLogic):
 
   @staticmethod
   def _installLightTheTorch():
-    slicer.util.pip_install('light-the-torch>=0.5')
+    # Install from the Slicer fork which includes support for newer CUDA
+    # versions (cu128+) needed for Blackwell and newer GPU architectures.
+    # The upstream PyPI release (0.8.0) only supports up to cu126.
+    slicer.util.pip_install(
+      'https://github.com/Slicer/light-the-torch/archive/main.zip')
 
   @staticmethod
   def getCompatibleComputationBackends(forceComputationBackend=None, torchVersionRequirement=None):

--- a/PyTorchUtils/PyTorchUtils.py
+++ b/PyTorchUtils/PyTorchUtils.py
@@ -245,6 +245,7 @@ class PyTorchUtilsLogic(ScriptedLoadableModuleLogic):
   @staticmethod
   def _installLightTheTorch():
     # Install from the Slicer fork which is maintained for newer CUDA versions
+    # see: https://github.com/fepegar/SlicerPyTorch/pull/20
     slicer.util.pip_install(
       'https://github.com/Slicer/light-the-torch/archive/main.zip')
 


### PR DESCRIPTION
## Problem

The upstream PyPI release of `light-the-torch` (0.8.0) only has CUDA version mappings up to 12.6 (`cu126`). This causes `PyTorchUtils.installTorch()` to install a torch build that lacks kernel support for **Blackwell GPUs** (RTX 50xx series, compute capability 12.0, `sm_120`), resulting in:

```
torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device
```

## Fix

Install `light-the-torch` from the [Slicer fork](https://github.com/Slicer/light-the-torch) which added cu128/cu129/cu130/cu131 support in [this commit](https://github.com/Slicer/light-the-torch/commit/316617e8). Uses the GitHub archive ZIP URL to avoid requiring git on the user's system.

## Impact

This fix benefits **all extensions** that use `PyTorchUtils.installTorch()`, including:
- TotalSegmentator
- SlicerNNUNet  
- TractCloud (SlicerDMRI)
- Any other extension using the PyTorch extension for torch installation

## Discussion

- Should the Slicer fork publish a release to PyPI so we can use a version pin instead of the archive URL?
- Should `light-the-torch` upstream be updated, or is the Slicer fork the long-term home?