### PR TITLE
Resolve light-the-torch installation crash by mocking setuptools_scm version

### DIFF
--- a/PyTorchUtils/PyTorchUtils.py
+++ b/PyTorchUtils/PyTorchUtils.py
@@ -246,6 +246,8 @@ class PyTorchUtilsLogic(ScriptedLoadableModuleLogic):
   def _installLightTheTorch():
     # Install from the Slicer fork which is maintained for newer CUDA versions
     # see: https://github.com/fepegar/SlicerPyTorch/pull/20
+    import os
+    os.environ["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LIGHT_THE_TORCH"] = "0.8.0"
     slicer.util.pip_install(
       'https://github.com/Slicer/light-the-torch/archive/main.zip')
 


### PR DESCRIPTION
### Description
This PR fixes a crash that currently prevents the installation of `light-the-torch` when triggered by `PyTorchUtilsLogic._installLightTheTorch()`.

**The Problem:**
Currently, the script downloads `light-the-torch` as a `.zip` archive from the `main` branch (as established in #20). The upstream repository enforced strict versioning via `setuptools_scm`. Because the downloaded `.zip` archive lacks the hidden `.git` folder, `setuptools_scm` fails to generate a version number, causing the wheel build to immediately fail with a `LookupError`.

**The Solution:**
Instead of changing the URL to `git+https` (which would force all 3D Slicer end-users to install Git natively on their machines), this PR injects the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LIGHT_THE_TORCH` environment variable right before the `pip_install` call. 

This successfully tricks `setuptools_scm` into bypassing the missing `.git` folder check, allowing the wheel to build and install successfully from the existing `main.zip` URL.